### PR TITLE
Add pnpm as a dependency

### DIFF
--- a/app/components/ChatInterface.tsx
+++ b/app/components/ChatInterface.tsx
@@ -1,7 +1,7 @@
 import { useState, useRef, useEffect } from 'react';
 import { FiSend, FiSettings, FiInfo, FiSmile } from 'react-icons/fi';
 import { Picker } from 'emoji-mart';
-import 'emoji-mart/css/emoji-mart.css';
+import 'emoji-mart/css/emoji-mart.css?__remix_sideEffect__';
 
 export interface Message {
   id: string;

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,6 +1,6 @@
 export default {
   plugins: {
-    tailwindcss: {},
+    '@tailwindcss/postcss': {},
     autoprefixer: {},
   },
 };


### PR DESCRIPTION
Update PostCSS configuration and mark external path in ChatInterface.tsx.

* **postcss.config.js**
  - Replace `tailwindcss` with `@tailwindcss/postcss` in the plugins section.

* **app/components/ChatInterface.tsx**
  - Mark the path "emoji-mart/css/emoji-mart.css?__remix_sideEffect__" as external to exclude it from the bundle.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/dtecho/github-dnxemoqt-hqtshe2c/pull/4?shareId=ea689047-f540-46c2-bd36-b5640a281a37).